### PR TITLE
Watch ngModel

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -8,6 +8,7 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
   require: '^ngModel'
   scope: {
     ngModel: '='
+    defaultCountry: '@'
   }
 
   link: (scope, element, attrs, ctrl) ->
@@ -46,15 +47,20 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
 
     # Wait for ngModel to be set
     watchOnce = scope.$watch('ngModel', (newValue) ->
-      if newValue != null and newValue != undefined and newValue != ''
-        element.val newValue
+      # Wait to see if other scope variables were set at the same time
+      scope.$$postDigest ->
+        options.defaultCountry = scope.defaultCountry
         
-      element.intlTelInput(options)
+        if newValue != null and newValue != undefined and newValue != ''
+          element.val newValue
+        
+        element.intlTelInput(options)
 
-      unless options.utilsScript
-        element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
+        unless options.utilsScript
+          element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
       
-      watchOnce()
+        watchOnce()
+
     )
 
 

--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -6,7 +6,9 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
 
   restrict:   'A'
   require: '^ngModel'
-  scope: true
+  scope: {
+    ngModel: '='
+  }
 
   link: (scope, element, attrs, ctrl) ->
 
@@ -42,10 +44,20 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
       else
         options[key] = option
 
-    element.intlTelInput(options)
+    # Wait for ngModel to be set
+    watchOnce = scope.$watch('ngModel', (newValue) ->
+      if newValue != null and newValue != undefined and newValue != ''
+        element.val newValue
+        
+      element.intlTelInput(options)
 
-    unless options.utilsScript
-      element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
+      unless options.utilsScript
+        element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
+      
+      watchOnce()
+    )
+
+
 
     ctrl.$parsers.push (value) ->
       return value if !value


### PR DESCRIPTION
The initial value for ng-model was being ignored. The flag would not match the phone number until user started typing. I added a watcher for ngModel so that intlTelInput is initialized afterwards. 

I'm also allowing the default-country attribute to be an expression, which is evaluated once ngModel is set.

The watcher only fires once, so if you update the ng-model or default-country expression from your controller later on, that won't have any effect.